### PR TITLE
Updated ToS and Privacy Policy

### DIFF
--- a/src/app/components/pages/Privacy.jsx
+++ b/src/app/components/pages/Privacy.jsx
@@ -5,21 +5,21 @@ class Privacy extends React.Component {
         return (
             <div className="Privacy row">
                 <div className="column large-12">
-                    <h1>Steemit, Inc Privacy Policy</h1>
-                    <h2>Effective: May 25, 2018</h2>
+                    <h1>Touchit.Social Privacy Policy</h1>
+                    <h2>Effective: August 10, 2019</h2>
                     <p className="c0">
                         <span className="c1" />
                     </p>
                     <p className="c2">
                         <span>
-                            This Privacy Policy describes how Steemit collects,
+                            This Privacy Policy describes how Touchit.Social collects,
                             uses and discloses information, and what choices you
                             have with respect to the information. This Policy
                             applies to the
                         </span>
                         <span>
-                            &nbsp;Steemit.com, steemit subdomains (e.g.,
-                            signup.steemit.com) and services
+                            &nbsp;Touchit.Social, Touchit.Social subdomains (e.g.,
+                            signup.touchit.social) and services
                         </span>
                         <span className="c1">
                             &nbsp;(collectively, &ldquo;Services&rdquo;).
@@ -33,8 +33,8 @@ class Privacy extends React.Component {
                     </p>
                     <p className="c2">
                         <span className="c1">
-                            When we refer to &ldquo;Steemit&rdquo;, we mean the
-                            Steemit entity that acts as the controller of your
+                            When we refer to &ldquo;Touchit.Social&rdquo;, we mean the
+                            Touchit.Social entity that acts as the controller of your
                             information.
                         </span>
                     </p>
@@ -66,7 +66,7 @@ class Privacy extends React.Component {
                         <span className="c1">
                             If you are visiting this site from the European
                             Union (EU), see our Notice to EU Data Subjects below
-                            for our legal bases for processing and transfer of
+                            for our legal basis for processing and transfer of
                             your data.
                         </span>
                     </p>
@@ -402,11 +402,10 @@ class Privacy extends React.Component {
                             You may access information that you have voluntarily
                             provided through your account on the Services, and
                             to review, correct, or delete it by sending a
-                            request to privacy@steemit.com. You can request to
+                            request to privacy@visionindustry.com. You can request to
                             change contact choices, opt-out of our sharing with
                             others, and update your personal information and
-                            preferences. We may require that you are the you are
-                            the user who you say you are by proving that you
+                            preferences. We may require that you are the user who you say you are by proving that you
                             have control of your posting key via our conveyor
                             API. &nbsp;For more information about our conveyor
                             API please see{' '}
@@ -429,7 +428,7 @@ class Privacy extends React.Component {
                         <span className="c1">
                             &nbsp;We welcome your comments or questions about
                             this Policy, and you may contact us at:
-                            privacy@steemit.com.
+                            privacy@visionindustry.com.
                         </span>
                     </p>
                     <p className="c0">
@@ -548,7 +547,7 @@ class Privacy extends React.Component {
                             information, which are described in the table below.
                             If you have questions about the legal bases under
                             which we process your personal information, contact
-                            us at legal@steemit.com.
+                            us at legal@visionindustry.com.
                         </span>
                     </p>
                     <p className="c0">
@@ -606,7 +605,7 @@ class Privacy extends React.Component {
                             Where our use of your personal information is based
                             upon your consent, you have the right to withdraw it
                             anytime in the manner indicated in the Service or by
-                            contacting us at privacy@steemit.com
+                            contacting us at privacy@visionindustry.com
                         </span>
                     </p>
                     <p className="c0">
@@ -728,7 +727,7 @@ class Privacy extends React.Component {
                     <p className="c2">
                         <span>
                             You can submit these requests by email to
-                            privacy@steemit.com. We may request specific
+                            privacy@visionindustry.com. We may request specific
                             information from you to help us confirm your
                             identity and process your request. Applicable law
                             may require or permit us to decline your request. If
@@ -737,7 +736,7 @@ class Privacy extends React.Component {
                             submit a complaint about our use of your personal
                             information or response to your requests regarding
                             your personal information, you may contact us at
-                            privacy@steemit.com or submit a complaint to the
+                            privacy@visionindustry.com or submit a complaint to the
                             data protection regulator in your jurisdiction. You
                             can find your data protection regulator{' '}
                         </span>

--- a/src/app/help/en/tos.md
+++ b/src/app/help/en/tos.md
@@ -1,18 +1,8 @@
-Last Updated June 15, 2018
+Last Updated August 10, 2019
 
-Welcome to Steemit!  This agreement (the “Agreement”) between you and
-Steemit, Inc. (“we”, “us”, “our”) sets out your rights to access
-and use of steemit.com and any other products or services provided by us (the
-“Service”). If you are accepting this Agreement and using the Services on
-behalf of a company, organization, government, or other legal entity, you
-represent and warrant that you are authorized to do so and have the authority
-to bind such entity to this Agreement.  By accessing our Service, you agree
-that you have read, understood and accepted this Agreement.
+Welcome to Touchit.Social! This agreement (the “Agreement”) between you and Vision Industry Token (“we”, “us”, “our”) sets out your rights to access and use of touchit.social and any other products or services provided by us (the “Service”). If you are accepting this Agreement and using the Services on behalf of a company, organization, government, or other legal entity, you represent and warrant that you are authorized to do so and have the authority to bind such entity to this Agreement. By accessing our Service, you agree that you have read, understood and accepted this Agreement.
 
-If we decide to make changes to this Agreement, we will provide notice of those
-changes by updating the “Last Updated” date above or posting notice on
-steemit.com. Your continued use of the Service will confirm your acceptance of
-the changes.
+If we decide to make changes to this Agreement, we will provide notice of those changes by updating the “Last Updated” date above or posting notice on touchit.social. Your continued use of the Service will confirm your acceptance of the changes.
 
 ## 1. Privacy Policy
 
@@ -21,108 +11,41 @@ and disclose information about you.
 
 ## 2. Eligibility
 
-The Service is not targeted toward, nor intended for use by, anyone under the
-age of 13. You must be at least 13 years of age to access or use of the
-Service. If you are between 13 and 18 years of age (or the age of legal
-majority where you reside), you may only access or use the Service under the
-supervision of a parent or legal guardian who agrees to be bound by this
-Agreement.
+The Service is not targeted toward, nor intended for use by, anyone under the age of 18. You must be at least 18 years of age to access or use of the Service. If you are under 18 years of age (or the age of legal majority where you reside), you may not access or use the Service under any circumstances.
 
 ## 3. Copyright and Limited License
 
-We may retain data, text, photographs, images, video, audio, graphics,
-articles, comments, software, code, scripts, and other content supplied by us,
-the Steem blockchain or our licensors, which we call “Steemit Content.”
-Steemit Content is protected by intellectual property laws, including copyright
-and other proprietary rights of the United States and foreign countries. Except
-as explicitly stated in this Agreement, we do not grant any express or implied
-rights to use Steemit Content.
+We may retain data, text, photographs, images, video, audio, graphics, articles, comments, software, code, scripts, and other content supplied by us, the VIT blockchain or our licensors, which we call “VIT Content.” VIT Content is protected by intellectual property laws, including copyright and other proprietary rights of the United States and foreign countries. Except as explicitly stated in this Agreement, we do not grant any express or implied rights to use VIT Content.
 
-You are granted a limited, non-exclusive, non-transferable, and
-non-sublicensable license to access and use the Service and Steemit Content for
-your personal use. You retain ownership of and responsibility for Content you
-create or own ("Your Content"). If you're posting anything you did not create
-yourself or do not own the rights to, you agree that you are responsible for
-any Content you post; that you will only submit Content that you have the right
-to post; and that you will fully comply with any third-party licenses relating
-to Content you post.
+You are granted a limited, non-exclusive, non-transferable, and non-sublicensable license to access and use the Service and VIT Content for your personal use. You retain ownership of and responsibility for Content you create or own ("Your Content"). If you're posting anything you did not create yourself or do not own the rights to, you agree that you are responsible for any Content you post; that you will only submit Content that you have the right to post; and that you will fully comply with any third-party licenses relating to Content you post.
 
 ## 4. Trademark Policy
 
-“Steemit,”, the Steemit logo and any other product or service names, logos,
-slogans that may appear on the Service are trademarks of Steemit, Inc., and,
-may not be copied, imitated, or used, in whole or in part, unless explicitly
-permitted or without first receiving written permission from us to do so.  The
-look and feel of steemit.com and the Service is protected by copyright ©
-Steemit, Inc. All rights reserved. You may not duplicate, copy, or reuse any
-portion of the HTML/CSS, Javascript, or visual design elements or concepts
-without express written permission.
+“VIT,”, the VIT logo and any other product or service names, logos, slogans that may appear on the Service are trademarks of Vision Industry Token., and, may not be copied, imitated, or used, in whole or in part, unless explicitly permitted or without first receiving written permission from us to do so. The look and feel of touchit.social and the Service is protected by copyright © Vision Industry Token. All rights reserved. You may not duplicate, copy, or reuse any portion of the HTML/CSS, Javascript, or visual design elements or concepts without express written permission.
 
-We encourage third-party dapp developers building on top of the Steem
-blockchain to reach out to legal@steemit.com for all branding and licensing
-questions.
+We encourage third-party dapp developers building on top of the VIT blockchain to reach out to info@visionindustry.com for all branding and licensing questions.
 
-All other trademarks, registered trademarks, product names and company names or
-logos mentioned or used on our Service are the property of their respective
-owners and may not be copied, imitated, or used, in whole or in part, without
-the permission of the applicable trademark holder.  Reference to any products,
-services, processes or other information by name, trademark, manufacturer,
-supplier or otherwise does not constitute or imply endorsement, sponsorship, or
-recommendation by us.
+All other trademarks, registered trademarks, product names and company names or logos mentioned or used on our Service are the property of their respective owners and may not be copied, imitated, or used, in whole or in part, without the permission of the applicable trademark holder. Reference to any products, services, processes or other information by name, trademark, manufacturer, supplier or otherwise does not constitute or imply endorsement, sponsorship, or recommendation by us.
 
 ## 5. Assumption of Risk, Limitations on Liability.
 
-5.1.   You accept and acknowledge that there are risks associated with
-utilizing an Internet-based Steem blockchain account service including, but not
-limited to, the risk of failure of hardware, software and Internet connections,
-the risk of malicious software introduction, and the risk that third-parties
-may obtain unauthorized access to information stored within or associated with
-your Account, including, but not limited to your private key(s) (“Private
-Key”). You accept and acknowledge that we will not be responsible for any
-communication failures, disruptions, errors, distortions, or delays you may
-experience when using the Services, however caused.
+5.1. You accept and acknowledge that there are risks associated with utilizing an Internet-based VIT blockchain account service including, but not limited to, the risk of failure of hardware, software and Internet connections, the risk of malicious software introduction, and the risk that third-parties may obtain unauthorized access to information stored within or associated with your Account, including, but not limited to your private key(s) (“Private Key”). You accept and acknowledge that we will not be responsible for any communication failures, disruptions, errors, distortions, or delays you may experience when using the Services, however caused.
 
-5.2. We make no representation or warranty of any kind, express or implied,
-statutory, or otherwise, regarding the contents of the Service, information and
-functions made accessible through the Service, any hyperlinks to third-party
-websites, nor for any breach of security associated with the transmission of
-information through the Service or any website linked to by the Service.
+5.2. We make no representation or warranty of any kind, express or implied, statutory, or otherwise, regarding the contents of the Service, information and functions made accessible through the Service, any hyperlinks to third-party websites, nor for any breach of security associated with the transmission of information through the Service or any website linked to by the Service.
 
-5.3.  We will not be responsible or liable to you for any loss and take no
-responsibility for and will not be liable to you for any use of our Services,
-including but not limited to any losses, damages or claims arising from: (a)
-User error such as forgotten passwords, incorrectly constructed transactions,
-or mistyped Steem blockchain addresses; (b) Server failure or data loss; (c)
-Corrupted Account files; (d) Unauthorized access to applications; (e) Any
-unauthorized third-party activities, including without limitation the use of
-viruses, phishing, brute forcing or other means of attack against the Service
-or Services.
+5.3. We will not be responsible or liable to you for any loss and take no responsibility for and will not be liable to you for any use of our Services, including but not limited to any losses, damages or claims arising from: (a) User error such as forgotten passwords, incorrectly constructed transactions, or mistyped VIT blockchain addresses; (b) Server failure or data loss; (c) Corrupted Account files; (d) Unauthorized access to applications; (e) Any unauthorized third-party activities, including without limitation the use of viruses, phishing, brute forcing or other means of attack against the Service or Services.
 
-5.4.  We make no warranty that the Service or the server that makes it
-available, are free of viruses or errors, that its content is accurate, that it
-will be uninterrupted, or that defects will be corrected. We will not be
-responsible or liable to you for any loss of any kind, from action taken, or
-taken in reliance on material, or information, contained on the Service.
+5.4. We make no warranty that the Service or the server that makes it available, are free of viruses or errors, that its content is accurate, that it will be uninterrupted, or that defects will be corrected. We will not be responsible or liable to you for any loss of any kind, from action taken, or taken in reliance on material, or information, contained on the Service.
 
-5.5.  Subject to 6.1 below, any and all indemnities, warranties, terms, and
-conditions (whether express or implied) are hereby excluded to the fullest
-extent permitted under New York law.
+5.5. Subject to 6.1 below, any and all indemnities, warranties, terms, and conditions (whether express or implied) are hereby excluded to the fullest extent permitted under New York law.
 
-5.6.  We will not be liable, in contract, or tort (including, without
-limitation, negligence), other than where we have been fraudulent or made
-negligent misrepresentations.
+5.6. We will not be liable, in contract, or tort (including, without limitation, negligence), other than where we have been fraudulent or made negligent misrepresentations.
 
-5.7.  Nothing in this Agreement excludes or limits liability for death or
-personal injury caused by negligence, fraudulent misrepresentation, or any
-other liability which may not otherwise be limited or excluded under United
-States law.
+5.7. Nothing in this Agreement excludes or limits liability for death or personal injury caused by negligence, fraudulent misrepresentation, or any other liability which may not otherwise be limited or excluded under United States law.
 
-## 6. Agreement to Hold Steemit, Inc. Harmless
+## 6. Agreement to Hold Vision Industry Token Harmless
 
-6.1. You agree to hold harmless Steemit, Inc. (and each of our officers,
-directors, members, employees, agents, and affiliates) from any claim, demand,
-action, damage, loss, cost, or expense, including without limitation reasonable
-legal fees, arising out, or relating to:
+6.1. You agree to hold harmless Vision Industry Token. (and each of our officers, directors, members, employees, agents, and affiliates) from any claim, demand, action, damage, loss, cost, or expense, including without limitation reasonable legal fees, arising out, or relating to:
 
 6.1.1. Your use of, or conduct in connection with, our Services;
 
@@ -130,180 +53,71 @@ legal fees, arising out, or relating to:
 
 6.1.3. Violation of any rights of any other person or entity.
 
-6.2.  If you are obligated to indemnify us, we will have the right, in our sole
+6.2. If you are obligated to indemnify us, we will have the right, in our sole
 discretion, to control any action or proceeding (at our expense) and determine
 whether we will pursue a settlement of any action or proceeding.
 
 ## 7. No Liability for Third-Party Services and Content
 
-7.1. In using our Services, you may view content or utilize services provided
-by third parties, including links to web pages and services of such parties
-(“Third-Party Content”). We do not control, endorse, or adopt any
-Third-Party Content and will have no responsibility for Third-Party Content
-including, without limitation, material that may be misleading, incomplete,
-erroneous, offensive, indecent, or otherwise objectionable in your
-jurisdiction. In addition, your dealings or correspondence with such third
-parties are solely between you and the third parties. We are not responsible or
-liable for any loss or damage of any sort incurred because of any such dealings
-and you understand that your use of Third-Party Content, and your interactions
-with third parties, is at your own risk.
+7.1. In using our Services, you may view content or utilize services provided by third parties, including links to web pages and services of such parties (“Third-Party Content”). We do not control, endorse, or adopt any Third-Party Content and will have no responsibility for Third-Party Content including, without limitation, material that may be misleading, incomplete, erroneous, offensive, indecent, or otherwise objectionable in your jurisdiction. In addition, your dealings or correspondence with such third parties are solely between you and the third parties. We are not responsible or liable for any loss or damage of any sort incurred because of any such dealings and you understand that your use of Third-Party Content, and your interactions with third parties, is at your own risk.
 
 ## 8. Account Registration
 
-8.1. You need not use a Steem blockchain account provided by us, and you can
-create an account independently of the Service. If you would like to use part
-of the Service, you must create a Steem blockchain account (“Account”).
-When you create an Account, you are strongly advised to take the following
-precautions, as failure to do so may result in loss of access to, and/or
-control over, your Account: (b) Provide accurate and truthful information; (c)
-maintain the security of your Account by protecting your Account password and
-access to your computer and your Account; (e) Promptly notify us if you
-discover or otherwise suspect any security breaches related to your Account.
+8.1. You need not use a VIT blockchain account provided by us, and you can create an account independently of the Service. If you would like to use part of the Service, you must create a VIT blockchain account (“Account”). When you create an Account, you are strongly advised to take the following precautions, as failure to do so may result in loss of access to, and/or control over, your Account: (b) Provide accurate and truthful information; (c) maintain the security of your Account by protecting your Account password and access to your computer and your Account; (e) Promptly notify us if you discover or otherwise suspect any security breaches related to your Account.
 
-8.2. You hereby accept and acknowledge that you take responsibility for all
-activities that occur under your Account and accept all risks of any authorized
-or unauthorized access to your Account, to the maximum extent permitted by law.
+8.2. You hereby accept and acknowledge that you take responsibility for all activities that occur under your Account and accept all risks of any authorized or unauthorized access to your Account, to the maximum extent permitted by law.
 
-8.3. You acknowledge and understand that cryptography is a progressing field.
-Advances in code cracking or technical advances such as the development of
-quantum computers may present risks to the Services that you use and your
-Account, which could result in the theft or loss of your property. By using the
-Service or accessing Steemit Content, you acknowledge these inherent risks.
+8.3. You acknowledge and understand that cryptography is a progressing field. Advances in code cracking or technical advances such as the development of quantum computers may present risks to the Services that you use and your Account, which could result in the theft or loss of your property. By using the Service or accessing VIT Content, you acknowledge these inherent risks.
 
 ## 9. The Services
 
-9.1. As described in more detail below, the Services, among other things,
-provide software that facilitates the submission of Steem blockchain
-transaction data to the Steem blockchain without requiring you to access the
-Steem blockchain command line interface.
+9.1. As described in more detail below, the Services, among other things, provide software that facilitates the submission of VIT blockchain transaction data to the VIT blockchain without requiring you to access the VIT blockchain command line interface.
 
-9.2. Account and Private Keys. Should you agree to create an Account through
-our Service, we generate a cryptographic private and public key pair that are
-provided solely to you and completely owned by you; provided however that we
-not store passwords or Private Keys for our you.  We never have access to your
-Private Key and do not custody any Private Keys on your behalf, and therefore,
-assume no responsibility for the management of the Private Key tied to your
-Account.  The Private Key uniquely match the Account name and must be used in
-connection with the Account to authorize the transfer of STEEM and Steem
-Dollars from that Account. You are solely responsible for maintaining the
-security of your Private Keys. You must keep your Private Key access
-information secure. Failure to do so may result in the loss of control of
-STEEM, Steem Power and Steem Dollars associated with your Account.
+9.2. Account and Private Keys. Should you agree to create an Account through our Service, we generate a cryptographic private and public key pair that are provided solely to you and completely owned by you; provided however that we not store passwords or Private Keys for our you. We never have access to your Private Key and do not custody any Private Keys on your behalf, and therefore, assume no responsibility for the management of the Private Key tied to your Account. The Private Key uniquely match the Account name and must be used in connection with the Account to authorize the transfer of VIT from that Account. You are solely responsible for maintaining the security of your Private Keys. You must keep your Private Key access information secure. Failure to do so may result in the loss of control of VIT and VIT Power associated with your Account.
 
-9.3. No Password Retrieval. We do not receive or store your Account password or
-Private Keys. Your Private Key is your own and you are solely responsible for
-their safekeeping.  We cannot assist you with Account password retrieval,
-reset, or recovery. You are solely responsible for remembering your Account
-password. If you have not safely stored a backup of any Account and password
-pairs maintained in your Account, you accept and acknowledge that any STEEM,
-Steem Dollars and Steem Power you have associated with such Account will become
-permanently inaccessible if you do not have your Account password.
+9.3. No Password Retrieval. We do not receive or store your Account password or Private Keys. Your Private Key is your own and you are solely responsible for their safekeeping. We cannot assist you with Account password retrieval, reset, or recovery. You are solely responsible for remembering your Account password. If you have not safely stored a backup of any Account and password pairs maintained in your Account, you accept and acknowledge that any VIT and VIT Power you have associated with such Account will become permanently inaccessible if you do not have your Account password.
 
-9.4.  Transactions. All proposed Steem blockchain transactions must be
-confirmed and recorded in the Steem blockchain via the Steem distributed
-consensus network (a peer-to-peer network), which is not owned, controlled, or
-operated by us. The Steem blockchain is operated by a decentralized network of
-independent third parties. We have no control over the Steem blockchain and
-therefore cannot and will not ensure that any transaction details you submit
-via the Services will be confirmed on the Steem blockchain. You acknowledge and
-agree that the transaction details you submit via the Services may not be
-completed, or may be substantially delayed, by the Steem blockchain. You may
-use the Services to submit these details to the Steem blockchain.
+9.4. Transactions. All proposed VIT blockchain transactions must be confirmed and recorded in the VIT blockchain via the VIT distributed consensus network (a peer-to-peer network), which is not owned, controlled, or operated by us. The VIT blockchain is operated by a decentralized network of independent third parties. We have no control over the VIT blockchain and therefore cannot and will not ensure that any transaction details you submit via the Services will be confirmed on the VIT blockchain. You acknowledge and agree that the transaction details you submit via the Services may not be completed, or may be substantially delayed, by the VIT blockchain. You may use the Services to submit these details to the VIT blockchain.
 
-9.5.  No Storage or Transmission of STEEM, Steem Dollars or Steem Power. STEEM,
-in any of its forms (STEEM, Steem Dollars and Steem Power) is an intangible,
-digital asset controlled by you.  These assets exist only by virtue of the
-ownership record maintained on the Steem blockchain. The Service does not
-store, send, or receive STEEM, Steem Dollars, or Steem Power. Any transfer of
-title that might occur in any STEEM, Steem Dollars or Steem Power occurs on the
-Steem blockchain and not within the Services. We do not guarantee that the
-Service can affect the transfer of title or right in any STEEM, Steem Dollars
-or Steem Power.
+9.5. No Storage or Transmission of VIT or VIT Power. VIT, in any of its forms (VIT and VIT Power) is an intangible, digital asset controlled by you. These assets exist only by virtue of the ownership record maintained on the VIT blockchain. The Service does not store, send, or receive VIT or VIT Power. Any transfer of title that might occur in any VIT or VIT Power occurs on the VIT blockchain and not within the Services. We do not guarantee that the Service can affect the transfer of title or right in any VIT or VIT Power.
 
-9.6.  Relationship. Nothing in this Agreement is intended to nor shall create
-any partnership, joint venture, agency, consultancy, or trusteeship, between
-you and us.
+9.6. Relationship. Nothing in this Agreement is intended to nor shall create any partnership, joint venture, agency, consultancy, or trusteeship, between you and us.
 
-9.7. Accuracy of Information. You represent and warrant that any information
-you provide via the Services is accurate and complete. You accept and
-acknowledge that we are not responsible for any errors or omissions that you
-make in connection with any Steem blockchain transaction initiated via the
-Services, for instance, if you mistype an Account name or otherwise provide
-incorrect information. We strongly encourage you to review your transaction
-details carefully before completing them via the Services.
+9.7. Accuracy of Information. You represent and warrant that any information you provide via the Services is accurate and complete. You accept and acknowledge that we are not responsible for any errors or omissions that you make in connection with any VIT blockchain transaction initiated via the Services, for instance, if you mistype an Account name or otherwise provide incorrect information. We strongly encourage you to review your transaction details carefully before completing them via the Services.
 
-9.8. No Cancellations or Modifications. Once transaction details have been
-submitted to the Steem blockchain via the Services, The Services cannot assist
-you to cancel or otherwise modify your transaction details. We have no control
-over the Steem blockchain and do not have the ability to facilitate any
-cancellation or modification requests.
+9.8. No Cancellations or Modifications. Once transaction details have been submitted to the VIT blockchain via the Services, The Services cannot assist you to cancel or otherwise modify your transaction details. We have no control over the VIT blockchain and do not have the ability to facilitate any cancellation or modification requests.
 
-9.9. Taxes. It is your responsibility to determine what, if any, taxes apply to
-the transactions you for which you have submitted transaction details via the
-Services, and it is your responsibility to report and remit the correct tax to
-the appropriate tax authority. You agree that the we are not responsible for
-determining whether taxes apply to your Steem blockchain transactions or for
-collecting, reporting, withholding, or remitting any taxes arising from any
-Steem blockchain transactions.
+9.9. Taxes. It is your responsibility to determine what, if any, taxes apply to the transactions you for which you have submitted transaction details via the Services, and it is your responsibility to report and remit the correct tax to the appropriate tax authority. You agree that the we are not responsible for determining whether taxes apply to your VIT blockchain transactions or for collecting, reporting, withholding, or remitting any taxes arising from any VIT blockchain transactions.
 
 ## 10. Fees for Using the Services
 
-10.1. Fees Creating an Account. We do not currently charge fees for any
-Services in connection with the creation of Accounts, however we reserve the
-right to do so in future, and in such case any applicable fees will be
-displayed prior to you using any Service to which a fee applies.
+10.1. Fees Creating an Account. We do not currently charge fees for any Services in connection with the creation of Accounts, however we reserve the right to do so in future, and in such case any applicable fees will be displayed prior to you using any Service to which a fee applies.
 
-## 11. No Right to Cancel And/or Reverse Steem Transactions
+## 11. No Right to Cancel And/or Reverse VIT Transactions
 
-11.1. If you use a Service to which STEEM, Steem Dollars or Steem Power is
-transacted, you will not be able to change your mind once you have confirmed
-that you wish to proceed with the Service or transaction.
+11.1. If you use a Service to which VIT or VIT Power is transacted, you will not be able to change your mind once you have confirmed that you wish to proceed with the Service or transaction.
 
 ## 12. Discontinuation of Services.
 
-12.1. We may, in our sole discretion and without cost to you, with or without
-prior notice and at any time, modify or discontinue, temporarily or
-permanently, any portion of our Services. You are solely responsible for
-storing, outside of the Services, a backup of any Account and Private Key that
-you maintain in your Account.
+12.1. We may, in our sole discretion and without cost to you, with or without prior notice and at any time, modify or discontinue, temporarily or permanently, any portion of our Services. You are solely responsible for storing, outside of the Services, a backup of any Account and Private Key that you maintain in your Account.
 
-12.2. If you do not maintain a backup of your Account data outside of the
-Services, you will be may not be able to access STEEM, Steem Dollars and Steem
-Power associated with any Account maintained in your Account if we discontinue
-or deprecate the Services.
+12.2. If you do not maintain a backup of your Account data outside of the Services, you may not be able to access VIT and VIT Power associated with any Accounts maintained in your Account if we discontinue or deprecate the Services.
 
 ## 13. Suspension or Termination of Service.
 
-13.1. We may suspend or terminate your access to the Services in our sole
-discretion, immediately and without prior notice, and delete or deactivate your
-steemit.com account and all related information and files in such without cost
-to you, including, for instance, if you breach any term of this Agreement. In
-the event of termination, your access to the funds in your account will require
-you access to the Steem blockchain via the command line API or third party
-tool, and will require you to have access to your backup of your Account data
-including your Account and Private Keys.
+13.1. We may suspend or terminate your access to the Services in our sole discretion, immediately and without prior notice, and delete or deactivate your touchit.social account and all related information and files in such without cost to you, including, for instance, if you breach any term of this Agreement. In the event of termination, your access to the funds in your account will require you access to the VIT blockchain via the command line API or third party tool, and will require you to have access to your backup of your Account data including your Account and Private Keys.
 
 ## 14. User Conduct
 
-14.1. When accessing or using the Services, you agree that you will not commit
-any unlawful act, and that you are solely responsible for your conduct while
-using our Services. Without limiting the generality of the foregoing, you agree
-that you will not:
+14.1. When accessing or using the Services, you agree that you will not commit any unlawful act, and that you are solely responsible for your conduct while using our Services. Without limiting the generality of the foregoing, you agree that you will not:
 
-14.1.1. Use of our Services in any manner that could interfere with, disrupt,
-negatively affect, or inhibit other users from fully enjoying our Services, or
-that could damage, disable, overburden, or impair the functioning of our
-Services in any manner;
+14.1.1. Use of our Services in any manner that could interfere with, disrupt, negatively affect, or inhibit other users from fully enjoying our Services, or that could damage, disable, overburden, or impair the functioning of our Services in any manner;
 
-14.1.2.  Use our Services to pay for, support or otherwise engage in any
-activity prohibited by law, including, but not limited to illegal gambling,
-fraud, money-laundering, or terrorist financing activities.
+14.1.2.  Use our Services to pay for, support or otherwise engage in any activity prohibited by law, including, but not limited to illegal gambling, fraud, money-laundering, or terrorist financing activities.
 
 14.1.3. Use or attempt to use another user’s Account without authorization;
 
-14.1.4. Attempt to circumvent any content filtering techniques we employ, or
-attempt to access any service or area of our Services that you are not
-authorized to access;
+14.1.4. Attempt to circumvent any content filtering techniques we employ, or attempt to access any service or area of our Services that you are not authorized to access;
 
 14.1.5. Introduce to the Services any virus, Trojan, worms, logic bombs or
 other harmful material;
@@ -313,26 +127,23 @@ prohibited under this Section.
 
 ## 15. Copyright Complaints, the DMCA, and Takedowns
 
-15.1 We will respond to legitimate requests under the Digital Millennium
-Copyright Act ("DMCA"), and we retain the right to remove access to user
-content provided via the Service that we deem to be infringing the copyright of
-others. If you become aware of user content on the Service that infringes your
-copyright rights, you may submit a properly formatted DMCA request (see 17
-U.S.C. § 512) to Steemit, Inc.
+15.1 We will respond to legitimate requests under the Digital Millennium Copyright Act ("DMCA"), and we retain the right to remove access to user content provided via the Service that we deem to be infringing the copyright of others. If you become aware of user content on the Service that infringes your copyright rights, you may submit a properly formatted DMCA request (see 17 U.S.C. § 512) to Vision Industry Token.
 
-Misrepresentations of infringement can result in liability for monetary
-damages. You may want to consult an attorney before taking any action pursuant
-to the DMCA. A DMCA request can be sent to us via the contact information below:
+Misrepresentations of infringement can result in liability for monetary damages. You may want to consult an attorney before taking any action pursuant to the DMCA. A DMCA request can be sent to us via the contact information below:
 
 Copyright Agent
-
-Steemit, Inc.
-
-251 LITTLE FALLS DRIVE
-
-WILMINGTON, DE 19808
-
-copyright@steemit.com
+ 
+Vision Industry Token
+ 
+PO Box 159
+ 
+5582 MANOTICK MAIN STREET
+ 
+Manotick, Ontario, Canada
+ 
+K4M 0A1
+ 
+copyright@visionindustry.com
 
 Please send our Copyright Agent the following information:
 
@@ -357,9 +168,7 @@ information in your notice is accurate and that you are the copyright owner or
 are authorized to act on the copyright owner's behalf.
 
 15.2 Your right to file a counter-notice.  If you believe your user content was
-wrongly removed due to a mistake or misidentification of the material, you can s
-end a counter-notice to our Copyright Agent (contact information provided above)
- that includes the following:
+wrongly removed due to a mistake or misidentification of the material, you can send a counter-notice to our Copyright Agent (contact information provided above) that includes the following:
 
 1.        Your physical or electronic signature;
 
@@ -391,53 +200,19 @@ the copyrights or other intellectual property rights of others.
 
 ## 16. Indemnity
 
-All the things you do and all the information you submit or post to the Service
-remain your responsibility. Indemnity is basically a way of saying that you
-will not hold us legally liable for any of your content or actions that
-infringe the law or the rights of a third party or person in any way.
+All the things you do and all the information you submit or post to the Service remain your responsibility. Indemnity is basically a way of saying that you will not hold us legally liable for any of your content or actions that infringe the law or the rights of a third party or person in any way.
 
-Specifically, you agree to hold us, our affiliates, officers, directors,
-employees, agents, and third-party service providers harmless from and defend
-them against any claims, costs, damages, losses, expenses, and any other
-liabilities, including attorneys’ fees and costs, arising out of or related
-to your access to or use of the Service, your violation of this user agreement,
-and/or your violation of the rights of any third-party or person.
+Specifically, you agree to hold us, our affiliates, officers, directors, employees, agents, and third-party service providers harmless from and defend them against any claims, costs, damages, losses, expenses, and any other liabilities, including attorneys’ fees and costs, arising out of or related to your access to or use of the Service, your violation of this user agreement, and/or your violation of the rights of any third-party or person.
 
 ## 17. Disclaimers
 
-To the fullest extent permitted by applicable law, the Service and the Steemit
-Content are provided on an “as is” and “as available” basis, without
-warranties of any kind, either express or implied, including, without
-limitation, implied warranties of merchantability, fitness for a particular
-purpose, title and non-infringement and any warranties implied by any course of
-performance or usage of trade. The company does not represent or warrant that
-the Service and the Steemit Content: (a) will be secure or available at any
-time or location; (b) are accurate, complete, reliable, current, or error-free
-or that any defects or errors will be corrected; and (c) are free of viruses or
-other harmful components. Your use of the Service and Steemit Content is solely
-at your own risk. Some jurisdictions do not allow the disclaimer of implied
-terms in contracts with consumers, so some or all of the disclaimers in this
-Section may not apply to you.
+To the fullest extent permitted by applicable law, the Service and the VIT Content are provided on an “as is” and “as available” basis, without warranties of any kind, either express or implied, including, without limitation, implied warranties of merchantability, fitness for a particular purpose, title and non-infringement and any warranties implied by any course of performance or usage of trade. The company does not represent or warrant that the Service and the VIT Content: (a) will be secure or available at any time or location; (b) are accurate, complete, reliable, current, or error-free or that any defects or errors will be corrected; and (c) are free of viruses or other harmful components. Your use of the Service and VIT Content is solely at your own risk. Some jurisdictions do not allow the disclaimer of implied terms in contracts with consumers, so some or all of the disclaimers in this Section may not apply to you.
 
 ## 18. Limitation of liability
 
-To the fullest extent permitted by applicable law, in no event shall Steemit,
-Inc. or the any related party to Steemit, Inc., that includes but is not
-limited to, subsidiaries, vendors, or contractors, be liable for any special,
-indirect, incidental, consequential, exemplary or punitive damages, or any
-other damages of any kind, including, but not limited to, loss of use, loss of
-profits or loss of data, whether in an action in contract, tort (including, but
-not limited to, negligence) or otherwise, arising out of, or in any way
-connected with, the use of, or inability to use, the Service or the Steemit
-Content. To the fullest extent permitted by applicable law, in no event shall
-the aggregate liability of Steemit, Inc. or any related party, whether in
-contract, warranty, tort (including negligence, whether active, passive or
-imputed), product liability, strict liability or other theory, arising out of
-or relating to the use of or inability to use of the Service
+To the fullest extent permitted by applicable law, in no event shall Vision Industry Token. or any related party to Vision Industry Token., that includes but is not limited to, subsidiaries, vendors, or contractors, be liable for any special, indirect, incidental, consequential, exemplary or punitive damages, or any other damages of any kind, including, but not limited to, loss of use, loss of profits or loss of data, whether in an action in contract, tort (including, but not limited to, negligence) or otherwise, arising out of, or in any way connected with, the use of, or inability to use, the Service or the VIT Content. To the fullest extent permitted by applicable law, in no event shall the aggregate liability of Vision Industry Token. or any related party, whether in contract, warranty, tort (including negligence, whether active, passive or imputed), product liability, strict liability or other theory, arising out of or relating to the use of or inability to use of the Service.
 
-Some jurisdictions do not allow the exclusion or limitation of certain damages,
-so some or all of the exclusions and limitations in this Section may not apply
-to you.
+Some jurisdictions do not allow the exclusion or limitation of certain damages, so some or all of the exclusions and limitations in this Section may not apply to you.
 
 ## 19. Modifications to the Service
 
@@ -448,123 +223,40 @@ discontinuance of the Service.
 
 ## 20. Arbitration
 
-Please read the following section carefully because it requires you to
-arbitrate certain disputes with Steemit, Inc. and limits the way you can seek
-relief from Steemit, Inc. If you do not agree with this Section 20, please
-discontinue using the Service.
+Please read the following section carefully because it requires you to arbitrate certain disputes with Vision Industry Token and limits the way you can seek relief from Vision Industry Token. If you do not agree with this Section 20, please discontinue using the Service.
 
-20.1. Binding Arbitration. Except for disputes in which either party seeks to
-bring an individual action in small claims court or seeks injunctive or other
-equitable relief for the alleged unlawful use of copyrights, trademarks, trade
-names, logos, trade secrets or patents, you and Steemit, Inc.: (a) waive your
-right to have any and all disputes or Claims arising from this Agreement or
-Steemit, Inc. (collectively, “Disputes”) resolved in a court; and (b) waive
-your right to a jury trial. Instead, you and Steemit, Inc. will arbitrate
-Disputes through binding arbitration (which is the referral of a Dispute to one
-or more persons charged with reviewing the Dispute and making a final and
-binding determination to resolve it, instead of having the Dispute decided by a
-judge or jury in court).
+20.1. Binding Arbitration. Except for disputes in which either party seeks to bring an individual action in small claims court or seeks injunctive or other equitable relief for the alleged unlawful use of copyrights, trademarks, trade names, logos, trade secrets or patents, you and Vision Industry Token: (a) waive your right to have any and all disputes or Claims arising from this Agreement or Vision Industry Token (collectively, “Disputes”) resolved in a court; and (b) waive your right to a jury trial. Instead, you and Vision Industry Token will arbitrate Disputes through binding arbitration (which is the referral of a Dispute to one or more persons charged with reviewing the Dispute and making a final and binding determination to resolve it, instead of having the Dispute decided by a judge or jury in court).
 
-20.2. No Class Arbitrations, Class Actions or Representative Actions. You agree
-that any dispute is personal to you and Steemit, Inc. and that any such dispute
-will be resolved solely through individual arbitration and will not be brought
-as a class arbitration, class action or any other type of representative
-proceeding. Neither party agrees to class arbitration or to an arbitration in
-which an individual makes and attempt to resolve a dispute as a representative
-of another individual or group of individuals. Further, you and Steemit, Inc.
-agree that a dispute cannot be brought as a class, or other type of
-representative action, whether within or outside of arbitration, or on behalf
-of any other individual or group of individuals.
+20.2. No Class Arbitrations, Class Actions or Representative Actions. You agree that any dispute is personal to you and Vision Industry Token and that any such dispute will be resolved solely through individual arbitration and will not be brought as a class arbitration, class action or any other type of representative proceeding. Neither party agrees to class arbitration or to an arbitration in which an individual makes and attempt to resolve a dispute as a representative of another individual or group of individuals. Further, you and Vision Industry Token agree that a dispute cannot be brought as a class, or other type of representative action, whether within or outside of arbitration, or on behalf of any other individual or group of individuals.
 
-20.3. Federal Arbitration Act. You agree that this Agreement affects interstate
-commerce and that the enforceability of this Section 20 shall be governed by,
-construed, and enforced, both substantively and procedurally, by the Federal
-Arbitration Act, 9 U.S.C. § 1 et seq. (the “FAA”) to the maximum extent
-permitted by applicable law.
+20.3. Federal Arbitration Act. You agree that this Agreement affects interstate commerce and that the enforceability of this Section 20 shall be governed by, construed, and enforced, both substantively and procedurally, by the Federal Arbitration Act, 9 U.S.C. § 1 et seq. (the “FAA”) to the maximum extent permitted by applicable law.
 
-20.4. Process. You agree that you will notify us in writing of any Dispute
-within thirty (30) days of when it arises so that the parties can attempt, in
-good faith, to resolve the Dispute informally. Notice to the us shall be
-provided by sending an email to legal@steemit.com. Your notice must include:
-(1) your name, postal address, and email address; (2) a description of the
-nature or basis of the Dispute; and (3) the specific relief that you are
-seeking. If we cannot agree how to resolve the Dispute within thirty (30) days
-of the us receiving the notice, either you or Steemit, Inc. may, as appropriate
-pursuant to this Section 20, commence an arbitration proceeding or file a claim
-in court. You agree that any arbitration or claim against us must be commenced
-or filed within one (1) year after the Dispute arose; otherwise, you agree that
-the claim is permanently barred (which means that you will no longer have the
-right to assert a claim regarding the Dispute). You have read, understand, and
-agree that: (a) any arbitration will occur in New York County, New York; (b)
-arbitration will be conducted confidentially by a single arbitrator in
-accordance with the rules of JAMS; and (c) the state or federal courts in New
-York will have exclusive jurisdiction over the enforcement of an arbitration
-award and over any Dispute between the parties that is not subject to
-arbitration. You may also litigate a Dispute in small claims court located in
-the county where you reside if the Dispute meets the requirements to be heard
-in small claims court.
+20.4. Process. You agree that you will notify us in writing of any Dispute within thirty (30) days of when it arises so that the parties can attempt, in good faith, to resolve the Dispute informally. Notice to us shall be provided by sending an email to info@visionindustry.com. Your notice must include: (1) your name, postal address, and email address; (2) a description of the nature or basis of the Dispute; and (3) the specific relief that you are seeking. If we cannot agree how to resolve the Dispute within thirty (30) days of the us receiving the notice, either you or Vision Industry Token may, as appropriate pursuant to this Section 20, commence an arbitration proceeding or file a claim in court. You agree that any arbitration or claim against us must be commenced or filed within one (1) year after the Dispute arose; otherwise, you agree that the claim is permanently barred (which means that you will no longer have the right to assert a claim regarding the Dispute). You have read, understand, and agree that: (a) any arbitration will occur in New York County, New York; (b) arbitration will be conducted confidentially by a single arbitrator in accordance with the rules of JAMS; and (c) the state or federal courts in New York will have exclusive jurisdiction over the enforcement of an arbitration award and over any Dispute between the parties that is not subject to arbitration. You may also litigate a Dispute in small claims court located in the county where you reside if the Dispute meets the requirements to be heard in small claims court.
 
-20.5. Authority of Arbitrator. As limited by the FAA, this Agreement and
-applicable JAMS rules, the arbitrator will have: (a) the exclusive authority
-and jurisdiction to make all procedural and substantive decisions regarding a
-Dispute; and (b) the authority to grant any remedy that would otherwise be
-available in court. The arbitrator may only conduct an individual arbitration
-and may not consolidate more than one individual’ s claims, preside over any
-type of class or representative proceeding or preside over any proceeding
-involving more than one individual.
+20.5. Authority of Arbitrator. As limited by the FAA, this Agreement and applicable JAMS rules, the arbitrator will have: (a) the exclusive authority and jurisdiction to make all procedural and substantive decisions regarding a Dispute; and (b) the authority to grant any remedy that would otherwise be available in court. The arbitrator may only conduct an individual arbitration and may not consolidate more than one individual’ s claims, preside over any type of class or representative proceeding or preside over any proceeding involving more than one individual.
 
-20.6. Rules of JAMS. The rules of, and additional information about, JAMS are
-available on the JAMS website at http://www.jamsadr.com/, as may be updated
-from time to time. By agreeing to be bound by this Agreement, you either: (a)
-acknowledge and agree that you have read and understand the rules of JAMS; or
-(b) waive your opportunity to read the rules of JAMS and any claim that the
-rules of JAMS are unfair or should not apply for any reason.
+20.6. Rules of JAMS. The rules of, and additional information about, JAMS are available on the JAMS website at http://www.jamsadr.com/, as may be updated from time to time. By agreeing to be bound by this Agreement, you either: (a) acknowledge and agree that you have read and understand the rules of JAMS; or (b) waive your opportunity to read the rules of JAMS and any claim that the rules of JAMS are unfair or should not apply for any reason.
 
-20.7. Severability. If any term, clause, or provision of this Section 20 is
-held invalid or unenforceable, it will be so held to the minimum extent
-required by law and all other terms, clauses or provisions will remain valid
-and enforceable. Further, the waivers set forth in Section 20.2 are severable
-from the other provisions of this Agreement and will remain valid and
-enforceable, except as prohibited by applicable law.
+20.7. Severability. If any term, clause, or provision of this Section 20 is held invalid or unenforceable, it will be so held to the minimum extent required by law and all other terms, clauses or provisions will remain valid and enforceable. Further, the waivers set forth in Section 20.2 are severable from the other provisions of this Agreement and will remain valid and enforceable, except as prohibited by applicable law.
 
 ## 21. Applicable Law and Venue
 
-This Agreement and your access to and use of the Service and the Steemit
-Content will be governed by, and construed in accordance with, the laws of New
-York, without resort to its conflict of law provisions. To the extent the
-arbitration provision in Section 20 does not apply and the Dispute cannot be
-heard in small claims court, you agree that any action at law or in equity
-arising out of, or relating to, this Agreement shall be filed only in the state
-and federal courts located in New York County, New York and you hereby
-irrevocably and unconditionally consent and submit to the exclusive
-jurisdiction of such courts over any suit, action or proceeding arising out of
-this Agreement.
+This Agreement and your access to and use of the Service and the VIT Content will be governed by, and construed in accordance with, the laws of New York, without resort to its conflict of law provisions. To the extent the arbitration provision in Section 20 does not apply and the Dispute cannot be heard in small claims court, you agree that any action at law or in equity arising out of, or relating to, this Agreement shall be filed only in the state and federal courts located in New York County, New York and you hereby irrevocably and unconditionally consent and submit to the exclusive jurisdiction of such courts over any suit, action or proceeding arising out of this Agreement.
 
 ## 22. Termination
 
-We reserve the right, without notice and in our sole discretion, to terminate
-your license to access and use of the Service, which includes, steemit.com, and
-to block or prevent your future access to, and use of, the Service that we
-provide.
+We reserve the right, without notice and in our sole discretion, to terminate your license to access and use of the Service, which includes, touchit.social, and to block or prevent your future access to, and use of, the Service that we provide.
 
 ## 23. Severability
 
-If any term, clause, or provision of this Agreement is deemed to be unlawful,
-void or for any reason unenforceable, then that term, clause or provision shall
-be deemed severable from this Agreement and shall not affect the validity and
-enforceability of any remaining provisions.
+If any term, clause, or provision of this Agreement is deemed to be unlawful, void or for any reason unenforceable, then that term, clause or provision shall be deemed severable from this Agreement and shall not affect the validity and enforceability of any remaining provisions.
 
 ## 24. Changes
 
-This Agreement is the entire agreement between you and us concerning the
-Service. It supersedes all prior or contemporaneous agreements between you and
-us. We may modify this user agreement at any time. If we make changes to this
-agreement that materially affect your rights, we will provide notice and keep
-this edition available as an archive on steemit.com. By continuing to use the
-Services after a change to this agreement, you agree to those changes.
+This Agreement is the entire agreement between you and us concerning the Service. It supersedes all prior or contemporaneous agreements between you and us. We may modify this user agreement at any time. If we make changes to this agreement that materially affect your rights, we will provide notice and keep this edition available as an archive on touchit.social. By continuing to use the Services after a change to this agreement, you agree to those changes.
 
 ## 25. Contact Information
 
-Notices to Steemit, Inc. should be directed to legal@steemit.com.
+Notices to Vision Industry Token should be directed to info@visionindustry.com.
 
 


### PR DESCRIPTION
TOS somehow got overwritten with the original steemit version at some point since we updated it back in January. I made modifications to our January version to replace Vice Industry Token with Vision Industry Token, vicetoken.com with visionindustry.com and updated @vicetoken.com emails with visionindustry.com emails.

I updated Privacy Policy to simply remove mentions of Steemit and replace with Touchit.Social or Vision Industry Token where appropriate.
